### PR TITLE
Fix error when `--headers` option is not used.

### DIFF
--- a/urlstream.py
+++ b/urlstream.py
@@ -42,6 +42,9 @@ def open(url, mode=None, trace=False, headers=None):
     'mode' is ignored, it is there to be argument compatible with file.open()
     """
 
+    if headers is None:
+        headers = {}
+
     handlers = []
     if trace:
         handlers.append(urllib.request.HTTPSHandler(debuglevel=1))


### PR DESCRIPTION
This fix avoids passing `None` rather than an empty dictionary to `Request(...)` which otherwise leads to this error:

    ERROR: 'NoneType' object has no attribute 'items'

which has the traceback[0]:

    [...snip...]
      File "/<path>/zipdump/urlstream.py", line 69, in open
        return urlstream(Request(method + basepath + query, headers=headers))
      File "/usr/lib/python3.6/urllib/request.py", line 335, in __init__
        for key, value in headers.items():
    AttributeError: 'NoneType' object has no attribute 'items'

(Tested with `./zipdump.py --quick --debug https://downloads.tuxfamily.org/godotengine/4.0/rc5/Godot_v4.0-rc5_export_templates.tpz`.)

----

Observations:

 * With this change headers do appear to still be sent successfully when they *are* supplied via `--headers` option.
 * I considered making a fix at the call-site in `zipdump`[1] but decided in `urlstream` was more robust.
 * A workaround for the issue is to supply a dummy header such as `--headers "x:x"`.

[0] https://github.com/nlitsme/zipdump/blob/f0f7013fadf7789d5cf2bf48d9d4664f32b4959b/urlstream.py#L69
[1] https://github.com/nlitsme/zipdump/blob/f0f7013fadf7789d5cf2bf48d9d4664f32b4959b/zipdump.py#L1370-L1375